### PR TITLE
filter testing app

### DIFF
--- a/apps/filters/app.css
+++ b/apps/filters/app.css
@@ -1,0 +1,81 @@
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    font-family: Arial;
+    color: white;
+    background: gray;
+}
+
+#map {
+    position: relative;
+    width: 100%;
+    height: 50%;
+}
+
+#filter-panel {
+    position: relative;
+    width: 100%;
+    height: 50%;
+}
+
+#filters {
+    overflow: auto;
+    height: 100%;
+}
+
+#filters * {
+    display: block;
+    white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    white-space: pre-wrap;       /* css-3 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
+    word-break: break-all;
+    white-space: normal;
+}
+
+#buttons {
+    width: 75%;
+    margin: 0 auto;
+    display: table;
+}
+
+#buttons span i {
+    display: block;
+    height: 24px;
+    margin: 0 auto;
+    width: auto;
+}
+
+#buttons span {
+    display: table-cell;
+    padding: 12px;
+}
+
+#status {
+    height: 1em;
+    font-weight: bold;
+    color: orange;
+    text-align: center;
+}
+
+.selected {
+    background: highlight;
+}
+
+#point i {
+    background: url(../shared/ol/theme/default/img/draw_point_on.png) no-repeat 50%;
+}
+
+#line i {
+    background: url(../shared/ol/theme/default/img/draw_line_on.png) no-repeat 50%;
+}
+
+#polygon i {
+    background: url(../shared/ol/theme/default/img/draw_polygon_on.png) no-repeat 50%;
+}
+
+#box i {
+    background: url(../shared/ol/theme/default/img/drag-rectangle-on.png) no-repeat 50%;
+}

--- a/apps/filters/app.js
+++ b/apps/filters/app.js
@@ -1,0 +1,115 @@
+var geomFilters = [
+    "INTERSECTS","DISJOINT","CROSSES","TOUCHES","WITHIN"
+];
+
+var filters = [
+    "PERSONS > 15000000",
+    "PERSONS BETWEEN 1000000 AND 3000000",
+    "STATE_NAME LIKE 'N%'",
+    "MALE > FEMALE",
+    "UNEMPLOY / (EMPLOYED + UNEMPLOY) > 0.07",
+    "IN ('states.1', 'states.12')",
+    "STATE_NAME IN ('New York', 'California', 'Montana', 'Texas')",
+    "STATE_NAME = 'New York' OR STATE_NAME = 'Montana'",
+    "STATE_NAME ='Maryland' AND STATE_ABBR='MD'",
+    "STATE_NAME <> 'Maryland'"
+];
+
+var feat, activeGeomFilter;
+
+function updateGeom() {
+    if (feat != null && activeGeomFilter != null) {
+        var params = {cql_filter:activeGeomFilter.textContent+"(geometry,"+feat.geometry+")"};
+        layer.mergeNewParams(params);
+    }
+}
+
+function update(what) {
+    layer.mergeNewParams({cql_filter:what.textContent});
+}
+
+function select(what) {
+    $(what).parent().children().removeClass("selected");
+    $(what).addClass("selected");
+}
+
+function init() {
+    map = new OpenLayers.Map({
+        div: "map"
+    });
+
+    map.addLayer(new OpenLayers.Layer.WMS("OSM 4326", "http://maps.opengeo.org/geowebcache/service/wms",
+            {layers: "openstreetmap", crs: "EPSG:4326", format: "image/png"}));
+    map.addLayer(layer = new OpenLayers.Layer.WMS("states", "/wms",
+            {layers: "states", crs: "EPSG:4326", format: "image/png", version:"1.3.0"}, {isBaseLayer: false, singleTile:true}));
+            map.addLayer(vLayer = new OpenLayers.Layer.Vector("vectors"));
+    layer.events.register("loadstart", null, function() {
+        $("#status").html("Loading...");
+    });
+    layer.events.register("loadend", null, function() {
+        $("#status").html("");
+    });
+    map.zoomToExtent([-124.731422, 24.955967, -66.969849, 49.371735]);
+
+    drawControls = {
+        point: new OpenLayers.Control.DrawFeature(vLayer,
+                OpenLayers.Handler.Point),
+        line: new OpenLayers.Control.DrawFeature(vLayer,
+                OpenLayers.Handler.Path),
+        polygon: new OpenLayers.Control.DrawFeature(vLayer,
+                OpenLayers.Handler.Polygon),
+        box: new OpenLayers.Control.DrawFeature(vLayer,
+                OpenLayers.Handler.RegularPolygon, {
+                    handlerOptions: {
+                        sides: 4,
+                        irregular: true
+                    }
+                }
+        )
+    };
+
+    for (var key in drawControls) {
+        var control = drawControls[key];
+        control.featureAdded = function(f) {
+            vLayer.removeAllFeatures();
+            vLayer.addFeatures([f]);
+            feat = f;
+            updateGeom();
+        };
+        map.addControl(control);
+        $("#" + key).click(function() {
+            for (var id in drawControls) {
+                drawControls[id].deactivate();
+            }
+            var control = drawControls[this.id];
+            if (!control.active) {
+                control.activate();
+                select(this);
+            }
+        });
+    }
+    $("#box").click();
+
+    for (var i=0; i< geomFilters.length; i++) {
+        var filter = $("<div>" + geomFilters[i] + "</div>");
+        filter.appendTo("#filters");
+        filter.click(function() {
+            activeGeomFilter = this;
+            updateGeom();
+            select(this);
+        });
+    }
+
+    for (var i=0; i< filters.length; i++) {
+        var filter = $("<div>" + filters[i] + "</div>");
+        filter.appendTo("#filters");
+        filter.click(function() {
+            vLayer.removeAllFeatures();
+            feat = null;
+            update(this);
+            select(this);
+        });
+    }
+}
+
+

--- a/apps/filters/index.html
+++ b/apps/filters/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Filters Testing App</title>
+        
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+
+        <link rel="stylesheet" href="../shared/ol/theme/default/style.mobile.css" type="text/css">
+        <link rel="stylesheet" href="../shared/ol/theme/default/style.css" type="text/css">
+        <link rel="stylesheet" href="app.css" type="text/css">
+
+        <script src="../shared/jquery.min.js"></script>
+        <script src="../shared/ol/OpenLayers.js"></script>
+        <script src="app.js"></script>
+    </head>
+    <body>        
+        <div id="map"></div>
+        <div id="buttons">
+            <span id="point"><i></i></span>
+            <span id="line"><i></i></span>
+            <span id="polygon"><i></i></span>
+            <span id="box"><i></i></span>
+        </div>
+        <div id="status"></div>
+        <div id="filter-panel">
+            <div id="filters"></div>
+        </div>
+        <script>
+            init();
+        </script>
+    </body>
+</html>
+


### PR DESCRIPTION
@jdeolive, first cut at this. Some filters are hard-coded to demonstrate specific functionality. For the spatial filters, I found it hard to get quality examples and thought it would be more fun/enlightening to allow user-entered geometries. So for the spatial filters, select a tool and draw a feature. Then change the spatial filter and see what happens.

I took the other examples straight from the geoserver page. Two don't work:
1. UNEMPLOY / (EMPLOYED + UNEMPLOY) > 0.07
2. IN ('states.1', 'states.12')

For (1), looks like math is totally not implemented.
For (2), IIRC, geojson yields no id for features

Obviously it would be hard to test 'equals' without having the example geometry but I figured one approach would be to use the `features` endpoint to get it.

Thoughts?
